### PR TITLE
Feature/duplicate todo

### DIFF
--- a/app/src/androidTest/java/com/tomerpacific/todo/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/tomerpacific/todo/MainViewModelTest.kt
@@ -111,4 +111,32 @@ class MainViewModelTest {
         job.cancel()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun addDuplicateTodoTest() = runTest {
+
+        val results = mutableListOf<TodoState>()
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { todoState ->
+                results.add(todoState)
+            }
+        }
+
+        viewModel.onEvent(TodoEvent.SetTodoDescription(TEST_TODO_ITEM_DESCRIPTION))
+
+        assert(results[0].todoItemDescription.isEmpty())
+        Thread.sleep(20)
+        assert(results[results.size - 1].todoItemDescription.isNotEmpty())
+        assert(results[results.size - 1].todoItemDescription == TEST_TODO_ITEM_DESCRIPTION)
+        viewModel.onEvent(TodoEvent.SaveTodo)
+        Thread.sleep(20)
+        assert(results[results.size - 1].todoItemDescription.isEmpty())
+        Thread.sleep(20)
+        viewModel.onEvent(TodoEvent.SetTodoDescription(TEST_TODO_ITEM_DESCRIPTION))
+        Thread.sleep(20)
+        assert(results[results.size - 1].isTodoItemADuplicate)
+        
+        job.cancel()
+    }
+
 }

--- a/app/src/androidTest/java/com/tomerpacific/todo/TodoFlowTest.kt
+++ b/app/src/androidTest/java/com/tomerpacific/todo/TodoFlowTest.kt
@@ -2,6 +2,7 @@ package com.tomerpacific.todo
 
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -88,6 +89,22 @@ class TodoFlowTest {
         }
 
         composeTestRule.onNodeWithText(TODO_TEST_ITEM_DESCRIPTION).assertDoesNotExist()
+
+    }
+
+    @Test
+    fun addDuplicateTodoTest() {
+        addTodoItemTest()
+
+        composeTestRule.onNodeWithContentDescription(FAB_BUTTON_CONTENT_DESCRIPTION).assertExists()
+        composeTestRule.onNodeWithContentDescription(FAB_BUTTON_CONTENT_DESCRIPTION).performClick()
+
+        composeTestRule.onNodeWithText(TODO_TEXT_FIELD_TEXT).assertExists()
+        composeTestRule.onNodeWithText(TODO_TEXT_FIELD_TEXT).performTextInput(TODO_TEST_ITEM_DESCRIPTION)
+
+        composeTestRule.onNodeWithText(TODO_ADD_BUTTON_TEXT).assertIsNotEnabled()
+
+        composeTestRule.onNodeWithText("There already exists a todo item with this description").assertExists()
 
     }
 

--- a/app/src/androidTest/java/com/tomerpacific/todo/TodoFlowTest.kt
+++ b/app/src/androidTest/java/com/tomerpacific/todo/TodoFlowTest.kt
@@ -23,6 +23,7 @@ private const val TODO_ADD_BUTTON_TEXT = "Add"
 private const val TODO_COMPLETE_BUTTON_CONTENT_DESCRIPTION = "Complete Todo"
 private const val TODO_DELETE_BUTTON_CONTENT_DESCRIPTION = "Delete Todo"
 private const val TODO_TEST_ITEM_DESCRIPTION = "Something"
+private const val TODO_LABEL_FOR_DUPLICATE_TEXT = "There already exists a todo item with this description"
 
 class TodoFlowTest {
 
@@ -104,7 +105,7 @@ class TodoFlowTest {
 
         composeTestRule.onNodeWithText(TODO_ADD_BUTTON_TEXT).assertIsNotEnabled()
 
-        composeTestRule.onNodeWithText("There already exists a todo item with this description").assertExists()
+        composeTestRule.onNodeWithText(TODO_LABEL_FOR_DUPLICATE_TEXT).assertExists()
 
     }
 

--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -73,7 +73,7 @@ class MainViewModel(application: Application): ViewModel() {
 
                 val itemDescription: String = state.value.todoItemDescription
 
-                if (itemDescription.isEmpty() || isDuplicateTodo(itemDescription)) {
+                if (itemDescription.isEmpty() || state.value.isTodoItemADuplicate) {
                     return
                 }
 
@@ -94,8 +94,10 @@ class MainViewModel(application: Application): ViewModel() {
                 todoItemsAlreadyAdded.add(todoItem)
             }
             is TodoEvent.SetTodoDescription -> {
+
                 _state.update { it.copy(
-                    todoItemDescription = event.todoDescription
+                    todoItemDescription = event.todoDescription,
+                    isTodoItemADuplicate = isDuplicateTodo(event.todoDescription)
                 ) }
             }
             is TodoEvent.ShowAddTodoDialog ->  {

--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -34,7 +34,7 @@ class MainViewModel(application: Application): ViewModel() {
     private val todoItemsRepository: TodoItemsRepository = TodoItemsRepository(application.todoItemsStore)
     private val todoListPreferencesRepository: TodoListPreferencesRepository = TodoListPreferencesRepository(application.todoListPreferencesDatastore)
     private val _state = MutableStateFlow(TodoState())
-    private var todoItemsAdded = mutableListOf<TodoItem>()
+    private var todoItemsAlreadyAdded = mutableListOf<TodoItem>()
     private val _todoItems = todoItemsRepository.todoItemsFlow.stateIn(
         viewModelScope, SharingStarted.WhileSubscribed(), emptyList<TodoItem>())
     val state: StateFlow<TodoState> = combine(_state, _todoItems) { state, todoItems ->
@@ -43,7 +43,7 @@ class MainViewModel(application: Application): ViewModel() {
             is TodoItems -> todoItems.itemsList
             else -> listOf()
         }
-        todoItemsAdded = when (items.isEmpty()) {
+        todoItemsAlreadyAdded = when (items.isEmpty()) {
             true -> mutableListOf()
             false -> items as MutableList<TodoItem>
         }
@@ -62,7 +62,7 @@ class MainViewModel(application: Application): ViewModel() {
                 viewModelScope.launch {
                     todoItemsRepository.removeTodoItem(event.todo)
                 }
-                todoItemsAdded.remove(event.todo)
+                todoItemsAlreadyAdded.remove(event.todo)
             }
             is TodoEvent.HideAddTodoDialog -> {
                 _state.update { it.copy(
@@ -91,7 +91,7 @@ class MainViewModel(application: Application): ViewModel() {
                     todoItemDescription = ""
                 ) }
 
-                todoItemsAdded.add(todoItem)
+                todoItemsAlreadyAdded.add(todoItem)
             }
             is TodoEvent.SetTodoDescription -> {
                 _state.update { it.copy(
@@ -132,11 +132,11 @@ class MainViewModel(application: Application): ViewModel() {
                 todoItems = listOf()
             )}
         }
-        todoItemsAdded.clear()
+        todoItemsAlreadyAdded.clear()
     }
 
     private fun isDuplicateTodo(todoDescription: String): Boolean {
-        return todoItemsAdded.any { todoItem ->
+        return todoItemsAlreadyAdded.any { todoItem ->
             todoItem.itemDescription == todoDescription
         }
     }

--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -62,7 +62,6 @@ class MainViewModel(application: Application): ViewModel() {
                 viewModelScope.launch {
                     todoItemsRepository.removeTodoItem(event.todo)
                 }
-                todoItemsAlreadyAdded.remove(event.todo)
             }
             is TodoEvent.HideAddTodoDialog -> {
                 _state.update { it.copy(
@@ -90,8 +89,6 @@ class MainViewModel(application: Application): ViewModel() {
                     isAddingTodo = false,
                     todoItemDescription = ""
                 ) }
-
-                todoItemsAlreadyAdded.add(todoItem)
             }
             is TodoEvent.SetTodoDescription -> {
 
@@ -134,7 +131,6 @@ class MainViewModel(application: Application): ViewModel() {
                 todoItems = listOf()
             )}
         }
-        todoItemsAlreadyAdded.clear()
     }
 
     private fun isDuplicateTodo(todoDescription: String): Boolean {

--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -72,11 +72,8 @@ class MainViewModel(application: Application): ViewModel() {
             is TodoEvent.SaveTodo -> {
 
                 val itemDescription: String = state.value.todoItemDescription
-                if (itemDescription.isBlank()) {
-                    return
-                }
 
-                if (isDuplicateTodo(itemDescription)) {
+                if (itemDescription.isEmpty() || isDuplicateTodo(itemDescription)) {
                     return
                 }
 

--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -70,6 +70,10 @@ class MainViewModel(application: Application): ViewModel() {
                     return
                 }
 
+                if (isDuplicateTodo(itemDescription)) {
+                    return
+                }
+
                 val todoItem: TodoItem = TodoItem
                     .newBuilder()
                     .setItemId(UUID.randomUUID().toString())
@@ -124,5 +128,9 @@ class MainViewModel(application: Application): ViewModel() {
             )}
         }
 
+    }
+
+    private fun isDuplicateTodo(todoDescription: String): Boolean {
+        return todoItemsRepository.doesTodoAlreadyExist(todoDescription)
     }
 }

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
@@ -174,7 +174,11 @@ fun ShowAddTodoItemDialog(state: TodoState,
                             onEvent(TodoEvent.SetTodoDescription(userInput))
                         },
                         label = {
-                            Text("What do you want to do?")
+                            if (state.isTodoItemADuplicate) {
+                                Text("There already exists a todo item with this description")
+                            } else {
+                                Text("What do you want to do?")
+                            }
                         },
                         trailingIcon = {
                             Icon(imageVector = Icons.Default.Edit, "Edit Icon")

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
@@ -147,9 +147,10 @@ fun ShowAddTodoItemDialog(state: TodoState,
                           onConfirmation: () -> Unit) {
 
     val focusRequester = remember { FocusRequester() }
-    val textFieldError = remember {
+    val todoItemDescriptionError = remember {
         mutableStateOf(false)
     }
+
 
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(
@@ -170,9 +171,6 @@ fun ShowAddTodoItemDialog(state: TodoState,
                         modifier = Modifier.focusRequester(focusRequester),
                         value = state.todoItemDescription,
                         onValueChange = { userInput: String ->
-                            if (textFieldError.value && userInput.isNotEmpty()) {
-                                textFieldError.value = false
-                            }
                             onEvent(TodoEvent.SetTodoDescription(userInput))
                         },
                         label = {
@@ -181,7 +179,7 @@ fun ShowAddTodoItemDialog(state: TodoState,
                         trailingIcon = {
                             Icon(imageVector = Icons.Default.Edit, "Edit Icon")
                         },
-                        isError = textFieldError.value
+                        isError = state.isTodoItemADuplicate || todoItemDescriptionError.value
                     )
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
@@ -200,10 +198,11 @@ fun ShowAddTodoItemDialog(state: TodoState,
                     }
                     TextButton(
                         onClick = {
-                            textFieldError.value = state.todoItemDescription.isEmpty()
+                            todoItemDescriptionError.value = state.isTodoItemADuplicate
                             onConfirmation()
                        },
                         modifier = Modifier.padding(8.dp),
+                        enabled = state.todoItemDescription.isNotEmpty() && !state.isTodoItemADuplicate
                     ) {
                         Text("Add")
                     }

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -146,6 +147,9 @@ fun ShowAddTodoItemDialog(state: TodoState,
                           onConfirmation: () -> Unit) {
 
     val focusRequester = remember { FocusRequester() }
+    val textFieldError = remember {
+        mutableStateOf(false)
+    }
 
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(
@@ -162,11 +166,13 @@ fun ShowAddTodoItemDialog(state: TodoState,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Row(modifier = Modifier.fillMaxWidth()) {
-                    val textFieldError = state.todoItemDescription.isEmpty()
                     TextField(
                         modifier = Modifier.focusRequester(focusRequester),
                         value = state.todoItemDescription,
                         onValueChange = { userInput: String ->
+                            if (textFieldError.value && userInput.isNotEmpty()) {
+                                textFieldError.value = false
+                            }
                             onEvent(TodoEvent.SetTodoDescription(userInput))
                         },
                         label = {
@@ -175,7 +181,7 @@ fun ShowAddTodoItemDialog(state: TodoState,
                         trailingIcon = {
                             Icon(imageVector = Icons.Default.Edit, "Edit Icon")
                         },
-                        isError = textFieldError
+                        isError = textFieldError.value
                     )
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
@@ -193,7 +199,10 @@ fun ShowAddTodoItemDialog(state: TodoState,
                         Text("Cancel")
                     }
                     TextButton(
-                        onClick = { onConfirmation() },
+                        onClick = {
+                            textFieldError.value = state.todoItemDescription.isEmpty()
+                            onConfirmation()
+                       },
                         modifier = Modifier.padding(8.dp),
                     ) {
                         Text("Add")

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
@@ -31,8 +31,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -141,6 +145,8 @@ fun ShowAddTodoItemDialog(state: TodoState,
                           onDismissRequest: () -> Unit,
                           onConfirmation: () -> Unit) {
 
+    val focusRequester = remember { FocusRequester() }
+
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(
             modifier = Modifier
@@ -158,6 +164,7 @@ fun ShowAddTodoItemDialog(state: TodoState,
                 Row(modifier = Modifier.fillMaxWidth()) {
                     val textFieldError = state.todoItemDescription.isEmpty()
                     TextField(
+                        modifier = Modifier.focusRequester(focusRequester),
                         value = state.todoItemDescription,
                         onValueChange = { userInput: String ->
                             onEvent(TodoEvent.SetTodoDescription(userInput))
@@ -170,6 +177,9 @@ fun ShowAddTodoItemDialog(state: TodoState,
                         },
                         isError = textFieldError
                     )
+                    LaunchedEffect(Unit) {
+                        focusRequester.requestFocus()
+                    }
                 }
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoScreen.kt
@@ -156,19 +156,19 @@ fun ShowAddTodoItemDialog(state: TodoState,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Row(modifier = Modifier.fillMaxWidth()) {
+                    val textFieldError = state.todoItemDescription.isEmpty()
                     TextField(
                         value = state.todoItemDescription,
                         onValueChange = { userInput: String ->
-                            if (userInput.isNotEmpty()) {
-                                onEvent(TodoEvent.SetTodoDescription(userInput))
-                            }
+                            onEvent(TodoEvent.SetTodoDescription(userInput))
                         },
                         label = {
                             Text("What do you want to do?")
                         },
                         trailingIcon = {
                             Icon(imageVector = Icons.Default.Edit, "Edit Icon")
-                        }
+                        },
+                        isError = textFieldError
                     )
                 }
                 Row(

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoState.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoState.kt
@@ -7,4 +7,5 @@ data class TodoState(
     val todoItemDescription: String = "",
     val isAddingTodo: Boolean = false,
     val todoListTitle: String = "",
+    val isTodoItemADuplicate: Boolean = false
 )

--- a/app/src/main/java/service/TodoItemsRepository.kt
+++ b/app/src/main/java/service/TodoItemsRepository.kt
@@ -18,10 +18,17 @@ class TodoItemsRepository(private val todoItemsDataStore: DataStore<TodoItems>) 
             }
         }
 
+    private var _todoItemsAdded = mutableListOf<TodoItem>()
+
+    init {
+        _todoItemsAdded = TodoItems.getDefaultInstance().itemsList.toMutableList()
+    }
+
     suspend fun updateTodoItems(todoItem: TodoItem) {
         todoItemsDataStore.updateData { items ->
             items.toBuilder().addItems(todoItem).build()
         }
+        _todoItemsAdded.add(todoItem)
     }
 
     suspend fun removeTodoItem(todoItem: TodoItem) {
@@ -29,11 +36,19 @@ class TodoItemsRepository(private val todoItemsDataStore: DataStore<TodoItems>) 
             val index = items.itemsList.indexOf(todoItem)
             items.toBuilder().removeItems(index).build()
         }
+        _todoItemsAdded.remove(todoItem)
     }
 
     suspend fun removeAllTodoItems() {
         todoItemsDataStore.updateData { items ->
             items.toBuilder().clearItems().build()
+        }
+        _todoItemsAdded.clear()
+    }
+
+    fun doesTodoAlreadyExist(todoItemDescription: String): Boolean {
+        return _todoItemsAdded.any { todoItem ->
+            todoItem.itemDescription == todoItemDescription
         }
     }
 

--- a/app/src/main/java/service/TodoItemsRepository.kt
+++ b/app/src/main/java/service/TodoItemsRepository.kt
@@ -18,17 +18,10 @@ class TodoItemsRepository(private val todoItemsDataStore: DataStore<TodoItems>) 
             }
         }
 
-    private var _todoItemsAdded = mutableListOf<TodoItem>()
-
-    init {
-        _todoItemsAdded = TodoItems.getDefaultInstance().itemsList.toMutableList()
-    }
-
     suspend fun updateTodoItems(todoItem: TodoItem) {
         todoItemsDataStore.updateData { items ->
             items.toBuilder().addItems(todoItem).build()
         }
-        _todoItemsAdded.add(todoItem)
     }
 
     suspend fun removeTodoItem(todoItem: TodoItem) {
@@ -36,19 +29,11 @@ class TodoItemsRepository(private val todoItemsDataStore: DataStore<TodoItems>) 
             val index = items.itemsList.indexOf(todoItem)
             items.toBuilder().removeItems(index).build()
         }
-        _todoItemsAdded.remove(todoItem)
     }
 
     suspend fun removeAllTodoItems() {
         todoItemsDataStore.updateData { items ->
             items.toBuilder().clearItems().build()
-        }
-        _todoItemsAdded.clear()
-    }
-
-    fun doesTodoAlreadyExist(todoItemDescription: String): Boolean {
-        return _todoItemsAdded.any { todoItem ->
-            todoItem.itemDescription == todoItemDescription
         }
     }
 


### PR DESCRIPTION
Resolves #23 

In order to know which todo items have already been added, a new parameter has been added to the viewmodel in order to save that.
A method has been created to check for duplication.
More so, a new field was added to TodoState in order to signify if the user is trying to add an item with a duplicated description.
This state helps the UI determine if it should show an error.

Also, made the TextField of the todo description have focus once the dialog is opened.

Added tests across different test classes to verify adding a duplicate todo scenario.