### PR TITLE
Replacing Use of Thread.sleep in ViewModel Test

### DIFF
--- a/app/src/androidTest/java/com/tomerpacific/todo/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/tomerpacific/todo/MainViewModelTest.kt
@@ -75,7 +75,6 @@ class MainViewModelTest {
                 }
             }
 
-
         viewModel.onEvent(TodoEvent.SetTodoDescription(TEST_TODO_ITEM_DESCRIPTION))
 
         val initialStateResult = results.receive()
@@ -89,13 +88,23 @@ class MainViewModelTest {
 
         viewModel.onEvent(TodoEvent.SaveTodo)
 
-        val afterSavingTodoResult = results.receive()
+        var afterSavingTodoResult = results.receive()
+
         assert(afterSavingTodoResult.todoItemDescription.isEmpty())
+
+        while (afterSavingTodoResult.todoItems.isEmpty()) {
+            afterSavingTodoResult = results.receive()
+        }
 
         val todoItem = afterSavingTodoResult.todoItems[0]
 
         viewModel.onEvent(TodoEvent.DeleteTodo(todoItem))
-        val afterRemovingTodoResult = results.receive()
+        var afterRemovingTodoResult = results.receive()
+
+        while (afterRemovingTodoResult.todoItems.isNotEmpty()) {
+            afterRemovingTodoResult = results.receive()
+        }
+
         assert(afterRemovingTodoResult.todoItems.isEmpty())
 
         job.cancel()

--- a/app/src/main/java/service/TodoItemsRepository.kt
+++ b/app/src/main/java/service/TodoItemsRepository.kt
@@ -26,8 +26,10 @@ class TodoItemsRepository(private val todoItemsDataStore: DataStore<TodoItems>) 
 
     suspend fun removeTodoItem(todoItem: TodoItem) {
         todoItemsDataStore.updateData { items ->
-            val index = items.itemsList.indexOf(todoItem)
-            items.toBuilder().removeItems(index).build()
+            when (val index = items.itemsList.indexOf(todoItem)) {
+                in 0 .. Int.MAX_VALUE -> items.toBuilder().removeItems(index).build()
+                else -> items.toBuilder().build()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #31 

Following the answer in SO, all test cases were converted to use Channel and to wait each time for the result.