### PR TITLE
Fix edit todo items list title dialog

### DIFF
--- a/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/MainViewModel.kt
@@ -78,7 +78,6 @@ class MainViewModel(application: Application) : ViewModel() {
             }
 
             is TodoEvent.SaveTodo -> {
-
                 val itemDescription: String = state.value.todoItemDescription
 
                 if (itemDescription.isEmpty() || state.value.isTodoItemADuplicate) {
@@ -103,7 +102,6 @@ class MainViewModel(application: Application) : ViewModel() {
             }
 
             is TodoEvent.SetTodoDescription -> {
-
                 _state.update {
                     it.copy(
                         todoItemDescription = event.todoDescription,
@@ -120,8 +118,23 @@ class MainViewModel(application: Application) : ViewModel() {
                 }
             }
 
-            is TodoEvent.SetTodoListTitle -> {
+            is TodoEvent.ShowEditTodoListTitleDialog -> {
+                _state.update {
+                    it.copy(
+                        isEditingTodoListTitle = true
+                    )
+                }
+            }
 
+            is TodoEvent.HideEditTodoListTitleDialog -> {
+                _state.update {
+                    it.copy(
+                        isEditingTodoListTitle = false
+                    )
+                }
+            }
+
+            is TodoEvent.SetTodoListTitle -> {
                 viewModelScope.launch {
                     todoListPreferencesRepository.updateTodoListTitle(event.todoListTitle)
                 }

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoEvent.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoEvent.kt
@@ -7,6 +7,8 @@ sealed interface TodoEvent {
     data class SetTodoDescription(val todoDescription: String): TodoEvent
     object ShowAddTodoDialog: TodoEvent
     object HideAddTodoDialog: TodoEvent
+    object ShowEditTodoListTitleDialog: TodoEvent
+    object HideEditTodoListTitleDialog: TodoEvent
     data class DeleteTodo(val todo: TodoItem): TodoEvent
     data class SetTodoListTitle(val todoListTitle: String): TodoEvent
     object RemoveAllTodos: TodoEvent

--- a/app/src/main/java/com/tomerpacific/todo/view/TodoState.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/TodoState.kt
@@ -6,6 +6,7 @@ data class TodoState(
     val todoItems: List<TodoItem> = emptyList(),
     val todoItemDescription: String = "",
     val isAddingTodo: Boolean = false,
+    val isEditingTodoListTitle: Boolean = false,
     val todoListTitle: String = "",
     val isTodoItemADuplicate: Boolean = false
 )

--- a/app/src/main/java/com/tomerpacific/todo/view/ui/AddTodoItemDialog.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/ui/AddTodoItemDialog.kt
@@ -30,16 +30,14 @@ import com.tomerpacific.todo.view.TodoState
 
 @Composable
 fun AddTodoItemDialog(state: TodoState,
-                      onEvent: (TodoEvent) -> Unit,
-                      onDismissRequest: () -> Unit,
-                      onConfirmation: () -> Unit) {
+                      onEvent: (TodoEvent) -> Unit) {
     val focusRequester = remember { FocusRequester() }
     val todoItemDescriptionError = remember {
         mutableStateOf(false)
     }
 
 
-    Dialog(onDismissRequest = { onDismissRequest() }) {
+    Dialog(onDismissRequest = { onEvent(TodoEvent.HideAddTodoDialog) }) {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
@@ -82,7 +80,7 @@ fun AddTodoItemDialog(state: TodoState,
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     TextButton(
-                        onClick = { onDismissRequest() },
+                        onClick = { onEvent(TodoEvent.HideAddTodoDialog) },
                         modifier = Modifier.padding(8.dp),
                     ) {
                         Text("Cancel")
@@ -90,7 +88,7 @@ fun AddTodoItemDialog(state: TodoState,
                     TextButton(
                         onClick = {
                             todoItemDescriptionError.value = state.isTodoItemADuplicate
-                            onConfirmation()
+                            onEvent(TodoEvent.SaveTodo)
                         },
                         modifier = Modifier.padding(8.dp),
                         enabled = state.todoItemDescription.isNotEmpty() && !state.isTodoItemADuplicate

--- a/app/src/main/java/com/tomerpacific/todo/view/ui/AddTodoItemDialog.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/ui/AddTodoItemDialog.kt
@@ -37,7 +37,10 @@ fun AddTodoItemDialog(state: TodoState,
     }
 
 
-    Dialog(onDismissRequest = { onEvent(TodoEvent.HideAddTodoDialog) }) {
+    Dialog(onDismissRequest = {
+        onEvent(TodoEvent.SetTodoDescription(""))
+        onEvent(TodoEvent.HideAddTodoDialog)
+    }) {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
@@ -80,7 +83,9 @@ fun AddTodoItemDialog(state: TodoState,
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     TextButton(
-                        onClick = { onEvent(TodoEvent.HideAddTodoDialog) },
+                        onClick = {
+                            onEvent(TodoEvent.SetTodoDescription(""))
+                            onEvent(TodoEvent.HideAddTodoDialog) },
                         modifier = Modifier.padding(8.dp),
                     ) {
                         Text("Cancel")

--- a/app/src/main/java/com/tomerpacific/todo/view/ui/TodoListTitleAlertDialog.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/ui/TodoListTitleAlertDialog.kt
@@ -11,10 +11,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -34,14 +32,12 @@ fun TodoListTitleAlertDialog(todoListTitle: String,
         mutableStateOf(TextFieldValue(todoListTitle, TextRange(todoListTitle.length)))
     }
 
-    var shouldShowTitleDialog by remember { mutableStateOf(true) }
-
     val focusRequester = remember {
         FocusRequester()
     }
 
     AlertDialog(onDismissRequest = {
-        shouldShowTitleDialog = false
+        onEvent(TodoEvent.HideEditTodoListTitleDialog)
     },
         text = {
             Column {
@@ -72,7 +68,7 @@ fun TodoListTitleAlertDialog(todoListTitle: String,
             TextButton(
                 onClick = {
                     onEvent(TodoEvent.SetTodoListTitle(todoTitle.value.text))
-                    shouldShowTitleDialog = false
+                    onEvent(TodoEvent.HideEditTodoListTitleDialog)
                 },
                 enabled = todoTitle.value.text.isNotEmpty()
             ) {
@@ -82,7 +78,7 @@ fun TodoListTitleAlertDialog(todoListTitle: String,
         dismissButton = {
             TextButton(
                 onClick = {
-                    shouldShowTitleDialog = false
+                    onEvent(TodoEvent.HideEditTodoListTitleDialog)
                 }
             ) {
                 Text("Cancel")

--- a/app/src/main/java/com/tomerpacific/todo/view/ui/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/ui/TodoScreen.kt
@@ -25,10 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,7 +49,6 @@ fun TodoScreen(
         false -> state.todoListTitle
     }
 
-    var shouldShowTitleDialog by remember { mutableStateOf(false) }
     val shouldShowRemoveAllTodosButton = state.todoItems.isNotEmpty()
 
     Scaffold(floatingActionButton = {
@@ -69,7 +64,7 @@ fun TodoScreen(
         }
 
     }) { paddingValues ->
-        if (shouldShowTitleDialog) {
+        if (state.isEditingTodoListTitle) {
             TodoListTitleAlertDialog(state.todoListTitle, onEvent)
         }
         LazyColumn(
@@ -83,7 +78,7 @@ fun TodoScreen(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     TextButton(onClick = {
-                            shouldShowTitleDialog = true
+                            onEvent(TodoEvent.ShowEditTodoListTitleDialog)
                     }) {
                         Text(
                             text = todoListTitleText,

--- a/app/src/main/java/com/tomerpacific/todo/view/ui/TodoScreen.kt
+++ b/app/src/main/java/com/tomerpacific/todo/view/ui/TodoScreen.kt
@@ -146,11 +146,7 @@ fun TodoScreen(
         }
 
         if (state.isAddingTodo) {
-            AddTodoItemDialog(state = state, onEvent = onEvent, onDismissRequest = {
-                onEvent(TodoEvent.HideAddTodoDialog)
-            }, onConfirmation = {
-                onEvent(TodoEvent.SaveTodo)
-            })
+            AddTodoItemDialog(state = state, onEvent = onEvent)
         }
     }
 }


### PR DESCRIPTION
Fixes #50 

Created two events and a variable in the state to hold the state of the alert dialog for editing the title of the todo list.